### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.9"
+  apt_packages:
+    - swig3
+
 
 
 # Build documentation in the docs/ directory with Sphinx


### PR DESCRIPTION
Updated readocs yaml file as to fix doc build up process.

The jamspell uses swig3 to bind module to python. So it is required to be installed in environment. Added swig3 readthedocs environment.