### PR TITLE
Remove Python 3.7 from workflow matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Python 3.7 is not supported by the Python Software Foundation since June 27, 2023. Likewise version 3.7 is no longer supported in Ubuntu 24.04. So let's drop testing and support for 3.7.
<details><summary>Details</summary>
- `.github/workflows/test.yml`: Removed Python 3.7 from the `python-version` matrix in the CI workflow.
</details> 

